### PR TITLE
fix export bug with negative scale

### DIFF
--- a/src/com/grapefrukt/exporter/serializers/data/XMLDataSerializer.as
+++ b/src/com/grapefrukt/exporter/serializers/data/XMLDataSerializer.as
@@ -190,7 +190,11 @@ package com.grapefrukt.exporter.serializers.data {
 				
 				// warning. here be matrix math!
 				var scaleX:Number = Math.sqrt(m.a * m.a + m.b * m.b);
+				if (m.a < 0)
+					scaleX = -scaleX;
 				var scaleY:Number = Math.sqrt(m.c * m.c + m.d * m.d);
+				if (m.d < 0)
+					scaleY = -scaleY;
 				xml.@scaleX 	= scaleX.toFixed(Settings.scalePrecision)
 				xml.@scaleY 	= scaleY.toFixed(Settings.scalePrecision);
 				


### PR DESCRIPTION
Grapefrukt incorrectly extractes a scale value from transformation matrix in the export to xml.
When scale is negative, in xml exported positive scale value and wrong rotation value.

Correct formulas for extracting offset, rotation and scale values ​​from transformation matrix can be found here - http://math.stackexchange.com/questions/13150/extracting-rotation-scale-values-from-2d-transformation-matrix
